### PR TITLE
Add common CI patterns

### DIFF
--- a/.github/workflows/set-msrv.yml
+++ b/.github/workflows/set-msrv.yml
@@ -1,0 +1,24 @@
+name: set-msrv
+
+on:
+  workflow_call:
+    inputs:
+      msrv:
+        required: true
+        type: string
+    outputs:
+      msrv:
+        value: ${{ jobs.set-msrv.outputs.msrv }}
+
+jobs:
+  set-msrv:
+    runs-on: ubuntu-latest
+    defaults:
+        run:
+            shell: bash
+    outputs:
+      msrv: ${{ steps.msrv.outputs.msrv }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: msrv
+        run: echo "::set-output name=msrv::$(echo ${{ inputs.msrv }})"

--- a/cross-install/action.yml
+++ b/cross-install/action.yml
@@ -1,0 +1,14 @@
+name: "cross-install"
+
+runs:
+  using: "composite"
+  steps:
+      - uses: actions/checkout@v2
+      - name: Install precompiled cross
+        run: |
+          export URL=$(curl -s https://api.github.com/repos/cross-rs/cross/releases/latest | \
+            jq -r '.assets[] | select(.name | contains("x86_64-unknown-linux-gnu.tar.gz")) | .browser_download_url')
+          wget -O /tmp/binaries.tar.gz $URL
+          tar -C /tmp -xzf /tmp/binaries.tar.gz
+          mv /tmp/cross ~/.cargo/bin
+        shell: bash


### PR DESCRIPTION
This adds an composite action for `cross-install` and an reusable workflow for `set-msrv`.

[Example how-to use `cross-install`](https://github.com/aewag/hashes/pull/2/files#diff-d1293e9cb6c8ff5bf3191c0f640a4f022a3d7c6d29f3edb56b545a8f93b783f9R30)

[Example how-to use `set-msrv`](https://github.com/aewag/hashes/actions/runs/1830812325/workflow#L20-L24)

@tarcieri @newpavlov What do you think about this as a start to collect common CI patterns?
