### PR TITLE
Add minimal-versions as reusable workflow

### DIFF
--- a/.github/workflows/minimal-versions.yml
+++ b/.github/workflows/minimal-versions.yml
@@ -1,0 +1,28 @@
+---
+name: minimal-versions
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        required: true
+        type: string
+
+jobs:
+  minimal-versions:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+        shell: bash
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          profile: minimal
+      - run: rm ../Cargo.toml
+      - run: cargo update -Z minimal-versions
+      - run: cargo test --release
+      - run: cargo test --release --all-features


### PR DESCRIPTION
I tested the `minimal-versions` workflow within [a branch of my forked hasher repository](https://github.com/aewag/hashes/pull/3). There is also an example [how-to use this workflow](https://github.com/aewag/hashes/pull/3/files#diff-830627c91fb30bb9972303e5ffed4e81682599d1ba84d04178ea241facdf69a4R49-R52)

Unfortunately, we can't get around explicitly specifying the `working-directory` via an input, but as the yml workflow names are always equal to the working-directory it can be used as [the input](https://github.com/aewag/hashes/pull/3/files#diff-830627c91fb30bb9972303e5ffed4e81682599d1ba84d04178ea241facdf69a4R52). 