### PR TITLE
curl: add --fail flag

### DIFF
--- a/cargo-hack-install/action.yml
+++ b/cargo-hack-install/action.yml
@@ -8,7 +8,7 @@ runs:
     # yamllint disable rule:line-length
     - name: Install pre-compiled cargo-hack
       run: |
-        export URL=$(curl -v --retry 10 -s https://api.github.com/repos/taiki-e/cargo-hack/releases/latest | \
+        export URL=$(curl --retry 10 --fail -s https://api.github.com/repos/taiki-e/cargo-hack/releases/latest | \
           jq -r '.assets[] | select(.name | contains("x86_64-unknown-linux-gnu.tar.gz")) | .browser_download_url')
         wget -O /tmp/binaries.tar.gz $URL
         tar -C /tmp -xzf /tmp/binaries.tar.gz

--- a/cross-install/action.yml
+++ b/cross-install/action.yml
@@ -8,7 +8,7 @@ runs:
     # yamllint disable rule:line-length
     - name: Install pre-compiled cross
       run: |
-        export URL=$(curl --retry 10 -s https://api.github.com/repos/cross-rs/cross/releases/latest | \
+        export URL=$(curl --retry 10 --fail -s https://api.github.com/repos/cross-rs/cross/releases/latest | \
           jq -r '.assets[] | select(.name | contains("x86_64-unknown-linux-gnu.tar.gz")) | .browser_download_url')
         wget -O /tmp/binaries.tar.gz $URL
         tar -C /tmp -xzf /tmp/binaries.tar.gz


### PR DESCRIPTION
By default curl does not retry on 40x errors, the flag changes it.

See #11