### PR TITLE
update actions used in GitHub Actions workflows

### DIFF
--- a/.github/workflows/minimal-versions.yml
+++ b/.github/workflows/minimal-versions.yml
@@ -16,7 +16,7 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
         shell: bash
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/set-msrv.yml
+++ b/.github/workflows/set-msrv.yml
@@ -20,6 +20,6 @@ jobs:
     outputs:
       msrv: ${{ steps.msrv.outputs.msrv }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - id: msrv
         run: echo "::set-output name=msrv::$(echo ${{ inputs.msrv }})"

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -14,5 +14,5 @@ jobs:
   yamllint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: yamllint --no-warnings .

--- a/cargo-cache/action.yml
+++ b/cargo-cache/action.yml
@@ -4,7 +4,7 @@ name: "cargo-cache"
 runs:
   using: "composite"
   steps:
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: |
           ~/.cargo/registry/index/

--- a/cargo-hack-install/action.yml
+++ b/cargo-hack-install/action.yml
@@ -4,7 +4,7 @@ name: "cargo-hack-install"
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # yamllint disable rule:line-length
     - name: Install pre-compiled cargo-hack
       run: |

--- a/cross-install/action.yml
+++ b/cross-install/action.yml
@@ -4,7 +4,7 @@ name: "cross-install"
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # yamllint disable rule:line-length
     - name: Install pre-compiled cross
       run: |


### PR DESCRIPTION
Updates the actions [`actions/checkout`](https://github.com/actions/checkout) and [`actions/cache`](https://github.com/actions/cache) to v3, their latest major release.

This should basically be backwards compatible, so I expect no breakage.