### PR TITLE
minimal-versions: pin nightly to 2022-12-25

### DIFF
--- a/.github/workflows/minimal-versions.yml
+++ b/.github/workflows/minimal-versions.yml
@@ -9,7 +9,7 @@ on:
         type: string
       nightly:
         description: 'The version of rust-nightly to be used'
-        default: 'nightly'
+        default: 'nightly-2022-12-25' # pinned due to rust-lang/rust#106247
         required: false
         type: string
 


### PR DESCRIPTION
Recent nightlies broke pretty much anything that uses object safety:

https://github.com/rust-lang/rust/issues/106247

This (temporarily) pins to a nightly before this regression occurred so we don't have to pin nightly everywhere object safety is used.