### PR TITLE
set-msrv: use $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/set-msrv.yml
+++ b/.github/workflows/set-msrv.yml
@@ -22,4 +22,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: msrv
-        run: echo "::set-output name=msrv::$(echo ${{ inputs.msrv }})"
+        run: echo "msrv=$(echo ${{ inputs.msrv }})" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The `set-output` command is [deprecated and will be removed](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).