### PR TITLE
minimal-versions: run tests using `stable` Rust

### DIFF
--- a/.github/workflows/minimal-versions.yml
+++ b/.github/workflows/minimal-versions.yml
@@ -8,8 +8,13 @@ on:
         required: true
         type: string
       nightly:
-        description: 'The version of rust-nightly to be used'
-        default: 'nightly-2023-03-03'
+        description: 'The version of rust-nightly to be used to resolve Cargo.lock'
+        default: 'nightly'
+        required: false
+        type: string
+      toolchain:
+        description: 'rustc version used to perform the build'
+        default: 'stable'
         required: false
         type: string
       install-zlint:
@@ -31,12 +36,14 @@ jobs:
       - name: Install zlint
         if: inputs.install-zlint
         uses: RustCrypto/actions/zlint-install@master
+        # Use `nightly` to compute a new Cargo.lock with -Z minimal-versions
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ inputs.nightly }}
+      - run: rm ../Cargo.toml
+      - run: cargo update -Z minimal-versions
+        # Perform tests
       - uses: RustCrypto/actions/cargo-hack-install@master
       - name: Test benches build
         run: cargo build --benches
-      - run: rm ../Cargo.toml
-      - run: cargo update -Z minimal-versions
       - run: cargo hack test --release --feature-powerset

--- a/.github/workflows/minimal-versions.yml
+++ b/.github/workflows/minimal-versions.yml
@@ -36,13 +36,16 @@ jobs:
       - name: Install zlint
         if: inputs.install-zlint
         uses: RustCrypto/actions/zlint-install@master
-        # Use `nightly` to compute a new Cargo.lock with -Z minimal-versions
+        # Use `nightly` to recompute Cargo.lock with -Z minimal-versions
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ inputs.nightly }}
       - run: rm ../Cargo.toml
       - run: cargo update -Z minimal-versions
         # Perform tests
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ inputs.toolchain }}
       - uses: RustCrypto/actions/cargo-hack-install@master
       - name: Test benches build
         run: cargo build --benches

--- a/.github/workflows/minimal-versions.yml
+++ b/.github/workflows/minimal-versions.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       nightly:
-        description: 'The version of rust-nightly to be used to resolve Cargo.lock'
+        description: 'rustc (nightly) version used to generate Cargo.lock'
         default: 'nightly'
         required: false
         type: string


### PR DESCRIPTION
Adds a configurable `toolchain` parameter to the reusable workflow for minimal-versions which allows a different toolchain than `nightly` to be used for the purposes of running tests.

`nightly` is only needed for the `-Z minimal-versions` resolution of Cargo.lock. We can avoid nightly breakages of which we've hit quite a few lately by reducing the scope of what we use `nightly` for to *just* that version resolution.

Additionally, this moves the resolution of Cargo.lock to earlier in the workflow so it applies to all steps. Previously benchmarks were being tested before the `-Z minimal-versions` resolution took place.