### PR TITLE
Test benches build on Nightly

### DIFF
--- a/.github/workflows/minimal-versions.yml
+++ b/.github/workflows/minimal-versions.yml
@@ -42,11 +42,11 @@ jobs:
           toolchain: ${{ inputs.nightly }}
       - run: rm ../Cargo.toml
       - run: cargo update -Z minimal-versions
+      - name: Test benches build
+        run: cargo build --benches
         # Perform tests
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ inputs.toolchain }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - name: Test benches build
-        run: cargo build --benches
       - run: cargo hack test --release --feature-powerset


### PR DESCRIPTION
The current version tries to build benches using stable toolchain, which causes [CI breakage](https://github.com/RustCrypto/hashes/actions/runs/6841425480/job/18601774840?pr=516).