### PR TITLE
minimal-versions: have `nightly_cmd` default to empty

### DIFF
--- a/.github/workflows/minimal-versions.yml
+++ b/.github/workflows/minimal-versions.yml
@@ -24,7 +24,7 @@ on:
         type: boolean
       nightly_cmd:
         type: string
-        default: cargo build --benches
+        default: ''
       stable_cmd:
         type: string
         default: cargo hack test --release --feature-powerset


### PR DESCRIPTION
Crates which want to check their benchmarks compile in a `minimal-versions` workflow can explicitly specify they want to do so.