### PR TITLE
minimal-versions: rename `nightly-cmd` and `stable-cmd`

### DIFF
--- a/.github/workflows/minimal-versions.yml
+++ b/.github/workflows/minimal-versions.yml
@@ -22,10 +22,10 @@ on:
         default: false
         required: false
         type: boolean
-      nightly_cmd:
+      nightly-cmd:
         type: string
         default: ''
-      stable_cmd:
+      stable-cmd:
         type: string
         default: cargo hack test --release --feature-powerset
 
@@ -48,10 +48,10 @@ jobs:
           toolchain: ${{ inputs.nightly }}
       - run: rm ../Cargo.toml
       - run: cargo update -Z minimal-versions
-      - run: ${{ inputs.nightly_cmd }}
+      - run: ${{ inputs.nightly-cmd }}
         # Perform tests
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ inputs.toolchain }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: ${{ inputs.stable_cmd }}
+      - run: ${{ inputs.stable-cmd }}


### PR DESCRIPTION
Uses "kebab case" for these parameter names, which is more idiomatic