### PR TITLE
Define intel-sde-install action

### DIFF
--- a/intel-sde-install/action.yaml
+++ b/intel-sde-install/action.yaml
@@ -1,0 +1,17 @@
+name: "intel-sde-install"
+description: "Install Intel SDE"
+inputs:
+  sde-full-version:
+    description: "SDE full version"
+    required: true
+runs:
+  using: composite
+  steps:
+    # yamllint disable rule:line-length
+    - shell: bash
+      run: |
+        curl -JLO "https://downloadmirror.intel.com/813591/sde-external-${{ inputs.sde-full-version }}-lin.tar.xz"
+        tar xvf sde-external-${{ inputs.sde-full-version }}-lin.tar.xz -C /opt
+    # yamllint disable rule:line-length
+    - shell: bash
+      run: echo "/opt/sde-external-${{ inputs.sde-full-version }}-lin" >> $GITHUB_PATH


### PR DESCRIPTION
This action installs the [intel software development emulator](https://www.intel.com/content/www/us/en/developer/articles/tool/software-development-emulator.html).

It is used in the CI job for the VAES backend in [this PR](https://github.com/RustCrypto/block-ciphers/pull/396).

The emulator is needed since GitHub Actions runners do not universally support AVX512.

QEMU could potentially be used as an alternative except that it does not support AVX512 and only recently has support for up to AVX2. Supposedly there is some support for VAES in recent versions but it may be limited to 256 variants. In any case, I could not get QEMU to work for this use case but Intel SDE works fine.

The reason for creating a separate action for this is because it may be useful for other crates intending to use recent `x86_64` features. (I will likely submit more PRs making use of this at least.)
