### PR TITLE
Update actions/cache to v4

### DIFF
--- a/cargo-cache/action.yml
+++ b/cargo-cache/action.yml
@@ -4,7 +4,7 @@ name: "cargo-cache"
 runs:
   using: "composite"
   steps:
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry/index/


### PR DESCRIPTION
v3 causes GitHub Actions warnings because it uses Node.js 16 instead of Node 20.