### PR TITLE
cargo-hack-install: do not run actions/checkout

### DIFF
--- a/cargo-hack-install/action.yml
+++ b/cargo-hack-install/action.yml
@@ -4,7 +4,6 @@ name: "cargo-hack-install"
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v6
     # yamllint disable rule:line-length
     - name: Install pre-compiled cargo-hack
       run: |


### PR DESCRIPTION
It's not necessary and breaks the minimal versions workflow.