### PR TITLE
intel-sde-install: provide default `sde-full-version`

### DIFF
--- a/intel-sde-install/README.md
+++ b/intel-sde-install/README.md
@@ -1,0 +1,13 @@
+# RustCrypto: `intel-sde-install` action
+
+Installs the Intel Software Development Emulator for AVX-512 CI.
+
+## Example
+
+```yaml
+steps:
+  - uses: actions/checkout@v6
+  - uses: RustCrypto/actions/intel-sde-install@master
+  - uses: dtolnay/rust-toolchain@master
+  - run: cargo test --features avx512
+```

--- a/intel-sde-install/action.yaml
+++ b/intel-sde-install/action.yaml
@@ -2,8 +2,8 @@ name: "intel-sde-install"
 description: "Install Intel SDE"
 inputs:
   sde-full-version:
+    default: "10.8.0-2026-03-15"
     description: "SDE full version"
-    required: true
 runs:
   using: composite
   steps:


### PR DESCRIPTION
That way we don't have to hardcode this everywhere