### PR TITLE
apt-install: massively simplify implementations

### DIFF
--- a/apt-install/action.yml
+++ b/apt-install/action.yml
@@ -1,65 +1,16 @@
-name: 'Cache and Install Apt (.deb) Packages'
-description: 'A GitHub Action to cache and install Apt (.deb) packages'
+name: Install Debian (.deb) Packages
 inputs:
   packages:
-    description: 'A space-separated list of Apt (.deb) packages to install'
+    description: space-separated list of Debian (.deb) packages to install
     required: true
 runs:
-  using: 'composite'
+  using: composite
   steps:
-    - name: Create deb-cache directory if not exists
-      run: mkdir -p ./deb-cache
+    - name: Update package index
       shell: bash
-
-    - name: Get package versions
-      id: get-versions
-      run: |
-        echo "${{ inputs.packages }}" | tr ' ' '\n' | sed 's/\\//g' | sed '/^$/d' > package-list.txt
-        cat package-list.txt
-        while IFS= read -r package; do
-          version=$(apt-cache policy $package | grep Candidate | awk '{print $2}')
-          echo "$package=$version" >> package-versions.txt
-        done < package-list.txt
-      shell: bash
-
-    - name: Set up cache for each package
-      id: cache-packages
-      uses: actions/cache@v4
-      with:
-        path: ./deb-cache
-        key: ${{ runner.os }}-deb-${{ hashFiles('package-versions.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-deb-
-
-    - name: Download packages if not cached
-      env:
-        DEBIAN_FRONTEND: 'noninteractive'
-      run: |
-        mkdir -p ./deb-cache
-        cp package-versions.txt ./deb-cache 
-        cp package-list.txt ./deb-cache 
-        cd ./deb-cache
-        while IFS= read -r package; do
-          echo "Processing package: $package"
-          version=$(grep "^$package=" package-versions.txt | cut -d '=' -f 2 || true)
-          echo "Processing version: $version"
-          package_file=$(ls $package*.deb 2>/dev/null | head -n 1 || true)
-
-          if [ -z "$package_file" ]; then
-            echo "Cache miss for $package. Downloading version $version..."
-            rm -f $package-*.deb
-            apt-get download $package=$version -y -qq --download-only ||
-              echo "Failed to download $package version $version"
-          else
-            echo "Cache hit for $package. Assuming correct version."
-          fi
-        done < package-list.txt
-      shell: bash
-
+      run: sudo apt-get update
     - name: Install packages
-      env:
-        DEBIAN_FRONTEND: 'noninteractive'
-      run: |
-        dpkg -i ./deb-cache/*.deb || sudo dpkg -i ./deb-cache/*.deb || apt-get install -f -y ||
-          sudo apt-get install -f -y
       shell: bash
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: sudo apt-get install -y ${{ inputs.packages }}


### PR DESCRIPTION
Well, after deploying #60 it's now breaking:

https://github.com/RustCrypto/elliptic-curves/actions/runs/30942249961/job/92103337350?pr=1911

The caching seems to be broken and debugging it is a nightmare. I think there are bugs in the way it's implemented but don't really care to spend the time to track them down.

So for now this just switches back to calling the equivalent of `apt-get update && apt-get install -y`, pretty much the dumbest thing that works.

I can look at potentially adding caching back properly later.