### PR TITLE
Add `setup-i686-gcc` action

### DIFF
--- a/setup-i686-gcc/action.yml
+++ b/setup-i686-gcc/action.yml
@@ -1,0 +1,10 @@
+name: Setup GitHub Actions runner for `i686-unknown-linux-gnu` builds
+runs:
+  using: composite
+  steps:
+    - name: Install packages
+      shell: bash
+      env:
+        DEBIAN_FRONTEND: noninteractive
+        NEEDRESTART_SUSPEND: 1
+      run: sudo apt-get update && apt-get install -y ${{ inputs.packages }}


### PR DESCRIPTION
Our main use case for the `apt-install` action (#60) is installing the packages we need to make `i686-unknown-linux-gnu` Rust programs build and run on 64-bit runners.

The main thing it was trying to do was avoid `apt-get update` via caching as updating the index was adding some 7s to each build, unfortunately that didn't work out (#65).

Another thing we can do is avoid installing the whole of `gcc-multilib` and disable the `needsrestart` hooks since we don't care about those. Instead it installs `libc6-dev-i386` and `lib32gcc-13-dev` which seem to be sufficient: see RustCrypto/crypto-bigint#1331.

This adds an action we can use everywhere we're doing setup for `i686-unknown-linux-gnu` builds which gives us one place to do these specific kinds of optimizations that don't need to apply to `apt-get` as a whole like `apt-install` was trying to do.