### PR TITLE
setup-i686-gcc: hardcode required `.deb` packages

### DIFF
--- a/setup-i686-gcc/action.yml
+++ b/setup-i686-gcc/action.yml
@@ -7,4 +7,4 @@ runs:
       env:
         DEBIAN_FRONTEND: noninteractive
         NEEDRESTART_SUSPEND: 1
-      run: sudo apt-get update && apt-get install -y ${{ inputs.packages }}
+      run: sudo apt-get update && apt-get install -y libc6-dev-i386 lib32gcc-13-dev


### PR DESCRIPTION
The whole goal of this action was to get rid of the packages parameter so we can have one place to configure a minified list.

This uses the `libc6-dev-i386` and `lib32gcc-13-dev` packages which were tested in RustCrypto/crypto-bigint#1331